### PR TITLE
Default rpm to build with MFT

### DIFF
--- a/ibdump.spec
+++ b/ibdump.spec
@@ -5,11 +5,18 @@
 %define upstream_arg UPSTREAM_KERNEL=yes
 %endif
 
+%bcond_with mstflint
+%if %{with mstflint}
+%define mstflint_arg WITH_MSTFLINT=yes
+%else
+%define mstflint_arg %{nil}
+%endif
+
 %if %{undefined make_build}
 %global make_build %{__make} %{?_smp_mflags}
 %endif
 
-%define make_opts WITH_MSTFLINT=yes %{upstream_arg} \\\
+%define make_opts %{mstflint_arg} %{upstream_arg} \\\
 	MSTFLINT_INCLUDE_DIR=/usr/include/mstflint  \\\
 	PREFIX=%{_prefix}
 


### PR DESCRIPTION
The mstflint rpm package still does not provide the required files
to build ibdump. Revert to MFT.

For those who do not have MFT, make it simple to use mstflint.

Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>