### PR TITLE
deb: default to building with MFT

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Tzafrir Cohen <mellanox@cohens.org.il>
 Build-Depends: debhelper (>= 9.0.0),
- mstflint,
+# mft-devel,
  libibverbs-dev,
 Standards-Version: 4.1.4
 Homepage: https://github.com/Mellanox/ibdump

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ BUILD_OFED = $(filter mlnx_ofed,$(DEB_BUILD_OPTIONS))
 ifeq (,$(BUILD_OFED))
 BUILD_OFED_ARG = UPSTREAM_KERNEL=yes
 endif
-make_opts = WITH_MSTFLINT=yes $(BUILD_OFED_ARG) MSTFLINT_INCLUDE_DIR=/usr/include/mstflint
+make_opts = $(BUILD_OFED_ARG)
 
 # This has to be exported to make some magic below work.
 export DH_OPTIONS

--- a/ibdump.spec
+++ b/ibdump.spec
@@ -16,9 +16,7 @@
 %global make_build %{__make} %{?_smp_mflags}
 %endif
 
-%define make_opts %{mstflint_arg} %{upstream_arg} \\\
-	MSTFLINT_INCLUDE_DIR=/usr/include/mstflint  \\\
-	PREFIX=%{_prefix}
+%define make_opts %{upstream_arg} PREFIX=%{_prefix}
 
 Summary: Mellanox InfiniBand sniffing application
 Name: ibdump 


### PR DESCRIPTION
build ibdump vs. mft in the deb as well.
Also remove the extra option added in the spec in previous commit.

Correction of commit message of the previous commit:

Build with MFT as we built with it before and the resulting ibdump
may differ when building vs. mstflint.

Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>