### PR TITLE
Build ibdump failed with the OFED-5.xx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ WITH_MFT   = yes
 endif
 endif
 
-ifeq ($(UPSTREAM_KERNEL),yes)
-CFLAGS    += -DUPSTREAM_KERNEL
+ifeq ($(LIBS_EXP),yes)
+CFLAGS    += -DLIBS_EXP
 endif
 LOADLIBES =
 LDFLAGS  +=

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ SDP, and FCoIB parsing, download the latest Wireshark daily build:
 # 4. How to Compile
 | Setup desired                      | Compilation command                                    |
 | ---------------------------------- | :-----------------------------------------------------:|
-| MFT Library + OFED kernel          | make [install]                                         |
-| MFT Library + UPSREAM Kernel	     | make UPSTREAM_KERNEL=yes [install]                     |
-| MSTFLINT Library + OFED kernel     | make WITH_MSTFLINT=yes [install]                       |
-| MSTFLINT Library + UPSREAM kernel  | make WITH_MSTFLINT=yes UPSTREAM_KERNEL=yes [install]   |
+| MFT Library + RDMA_CORE            | make [install]                                         |
+| MFT Library + LIBS_EXP     	     | make LIBS_EXP=yes [install]                            |
+| MSTFLINT Library + RDMA_CORE       | make WITH_MSTFLINT=yes [install]                       |
 | Without FW tools	                 | make WITHOUT_FW_TOOLS=yes [install]                    |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ SDP, and FCoIB parsing, download the latest Wireshark daily build:
 | Setup desired                      | Compilation command                                    |
 | ---------------------------------- | :-----------------------------------------------------:|
 | MFT Library + RDMA_CORE            | make [install]                                         |
-| MFT Library + LIBS_EXP     	     | make LIBS_EXP=yes [install]                            |
+| MFT Library + LIBS_EXP     	       | make LIBS_EXP=yes [install]                            |
 | MSTFLINT Library + RDMA_CORE       | make WITH_MSTFLINT=yes [install]                       |
 | Without FW tools	                 | make WITHOUT_FW_TOOLS=yes [install]                    |

--- a/build/make_ibdump_build
+++ b/build/make_ibdump_build
@@ -30,7 +30,7 @@ do_test=1
 without_fw_tools=0
 with_mstflint=0
 with_mft=0
-with_upstream_kernel=0
+with_libs_exp=0
 
 get_from_git() {
     ex git clone $git_repo
@@ -74,7 +74,7 @@ usage() {
     script=$(basename $0)
 
     echo "Usage: $script <--rc rc> [--ver version] [--repo repo] [--branch branch] [--git-rev rev/tag] [--notest]"
-    echo "[--with-upstream-kernel] [--with-mft] [--with-mstflint] [--without-fw-tools]"
+    echo "[--with-libs-exp] [--with-mft] [--with-mstflint] [--without-fw-tools]"
     echo ""
     echo "       This script pulls rev from git, copies the relevant files and creates a dist tar ball."
     echo "       It also opens the tar and makes for test."
@@ -123,8 +123,8 @@ while [ -n "$1" ]; do
             with_mft=1
             shift 1
             ;;
-        --with-upstream-kernel)
-            with_upstream_kernel=1
+        --with-libs-exp)
+            with_libs_exp=1
             shift 1
             ;;
         *)
@@ -198,8 +198,8 @@ if [ $with_mstflint -eq 1 ]; then
 sed -i '1iWITH_MSTFLINT    = yes' Makefile
 fi
 
-if [ $with_upstream_kernel -eq 1 ]; then
-sed -i '1iUPSTREAM_KERNEL    = yes' Makefile
+if [ $with_libs_exp -eq 1 ]; then
+sed -i '1iLIBS_EXP    = yes' Makefile
 fi
 
 # make dest dir and copy files

--- a/debian/rules
+++ b/debian/rules
@@ -14,8 +14,8 @@
 #export DH_VERBOSE=1
 
 BUILD_OFED = $(filter mlnx_ofed,$(DEB_BUILD_OPTIONS))
-ifeq (,$(BUILD_OFED))
-BUILD_OFED_ARG = UPSTREAM_KERNEL=yes
+ifneq (,$(BUILD_OFED))
+BUILD_OFED_ARG = LIBS_EXP=yes
 endif
 make_opts = $(BUILD_OFED_ARG)
 

--- a/ibdump.spec
+++ b/ibdump.spec
@@ -1,8 +1,8 @@
 %bcond_with mlnx_libs
 %if %{with mlnx_libs}
-%define upstream_arg %{nil}
+%define libs_exp_arg LIBS_EXP=yes
 %else
-%define upstream_arg UPSTREAM_KERNEL=yes
+%define libs_exp_arg %{nil}
 %endif
 
 %bcond_with mstflint
@@ -16,7 +16,7 @@
 %global make_build %{__make} %{?_smp_mflags}
 %endif
 
-%define make_opts %{upstream_arg} PREFIX=%{_prefix}
+%define make_opts %{libs_exp_arg} PREFIX=%{_prefix}
 
 Summary: Mellanox InfiniBand sniffing application
 Name: ibdump 


### PR DESCRIPTION
Description:
I changed the compilation flags in ibdump project.
OFED default verbs is changed to rdma-core, so ibdump must be aligned.

Issue: 2084499