### PR TITLE
Build ibdump failed with the OFED-5.xx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ WITH_MFT   = yes
 endif
 endif
 
-ifeq ($(UPSTREAM_KERNEL),yes)
-CFLAGS    += -DUPSTREAM_KERNEL
+ifeq ($(LIBS_EXP),yes)
+CFLAGS    += -DLIBS_EXP
 endif
 LOADLIBES =
 LDFLAGS  +=

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ SDP, and FCoIB parsing, download the latest Wireshark daily build:
 # 4. How to Compile
 | Setup desired                      | Compilation command                                    |
 | ---------------------------------- | :-----------------------------------------------------:|
-| MFT Library + OFED kernel          | make [install]                                         |
-| MFT Library + UPSREAM Kernel	     | make UPSTREAM_KERNEL=yes [install]                     |
-| MSTFLINT Library + OFED kernel     | make WITH_MSTFLINT=yes [install]                       |
-| MSTFLINT Library + UPSREAM kernel  | make WITH_MSTFLINT=yes UPSTREAM_KERNEL=yes [install]   |
+| MFT Library + RDMA_CORE            | make [install]                                         |
+| MFT Library + LIBS_EXP     	       | make LIBS_EXP=yes [install]                            |
+| MSTFLINT Library + RDMA_CORE       | make WITH_MSTFLINT=yes [install]                       |
 | Without FW tools	                 | make WITHOUT_FW_TOOLS=yes [install]                    |

--- a/build/make_ibdump_build
+++ b/build/make_ibdump_build
@@ -30,7 +30,7 @@ do_test=1
 without_fw_tools=0
 with_mstflint=0
 with_mft=0
-with_upstream_kernel=0
+with_libs_exp=0
 
 get_from_git() {
     ex git clone $git_repo
@@ -74,7 +74,7 @@ usage() {
     script=$(basename $0)
 
     echo "Usage: $script <--rc rc> [--ver version] [--repo repo] [--branch branch] [--git-rev rev/tag] [--notest]"
-    echo "[--with-upstream-kernel] [--with-mft] [--with-mstflint] [--without-fw-tools]"
+    echo "[--with-libs-exp] [--with-mft] [--with-mstflint] [--without-fw-tools]"
     echo ""
     echo "       This script pulls rev from git, copies the relevant files and creates a dist tar ball."
     echo "       It also opens the tar and makes for test."
@@ -123,8 +123,8 @@ while [ -n "$1" ]; do
             with_mft=1
             shift 1
             ;;
-        --with-upstream-kernel)
-            with_upstream_kernel=1
+        --with-libs-exp)
+            with_libs_exp=1
             shift 1
             ;;
         *)
@@ -198,8 +198,8 @@ if [ $with_mstflint -eq 1 ]; then
 sed -i '1iWITH_MSTFLINT    = yes' Makefile
 fi
 
-if [ $with_upstream_kernel -eq 1 ]; then
-sed -i '1iUPSTREAM_KERNEL    = yes' Makefile
+if [ $with_libs_exp -eq 1 ]; then
+sed -i '1iLIBS_EXP    = yes' Makefile
 fi
 
 # make dest dir and copy files

--- a/debian/rules
+++ b/debian/rules
@@ -13,9 +13,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-BUILD_OFED = $(filter mlnx_ofed,$(DEB_BUILD_OPTIONS))
-ifeq (,$(BUILD_OFED))
-BUILD_OFED_ARG = UPSTREAM_KERNEL=yes
+BUILD_OFED = $(filter mlnx_libs,$(DEB_BUILD_OPTIONS))
+ifneq (,$(BUILD_OFED))
+BUILD_OFED_ARG = LIBS_EXP=yes
 endif
 make_opts = $(BUILD_OFED_ARG)
 

--- a/ibdump.c
+++ b/ibdump.c
@@ -527,11 +527,9 @@ static int resources_create(struct resources *res)
         }
     } else {
 #ifndef WIN_NOT_SUPPORTED
-#ifdef UPSTREAM_KERNEL
-        res->mr = ibv_reg_mr(res->pd,NULL,
-                                res->entry_size * config.entries_num,
-                                IBV_ACCESS_LOCAL_WRITE);
-#else
+
+#ifdef LIBS_EXP
+
         struct ibv_exp_reg_mr_in in;
         in.pd = res->pd;
         in.addr = NULL;
@@ -544,9 +542,15 @@ static int resources_create(struct resources *res)
             return 1;
         }
         res->buf[0] = res->mr->addr;
-#endif
 
 #else
+
+    res->mr = ibv_reg_mr(res->pd,NULL,
+                                    res->entry_size * config.entries_num,
+                                    IBV_ACCESS_LOCAL_WRITE);
+
+#endif
+
         if (res->buf) {
             free(res->buf);
         }
@@ -585,10 +589,10 @@ static int resources_create(struct resources *res)
 
 #ifndef WIN_NOT_SUPPORTED
     if (res->port_attr.link_layer == IBV_LINK_LAYER_ETHERNET) {
-#ifdef UPSTREAM_KERNEL
-        qp_init_attr.qp_type    = IBV_QPT_RAW_PACKET;
-#else
+#ifdef LIBS_EXP
         qp_init_attr.qp_type    = IBV_QPT_RAW_ETH;
+#else
+        qp_init_attr.qp_type    = IBV_QPT_RAW_PACKET;
 #endif
     } else {
         qp_init_attr.qp_type    = IBV_QPT_UD;
@@ -839,30 +843,7 @@ int fourth_gen_set_sw_sniffer(struct resources *res, int mode,
     (void) is_tx;
     (void) is_rx;
 
-#ifdef UPSTREAM_KERNEL
-
-    if (mode != 0) {
-        struct ibv_flow_attr flow_attr;
-        memset(&flow_attr, 0, sizeof(flow_attr));
-
-        flow_attr.type = IBV_FLOW_ATTR_SNIFFER;
-        flow_attr.size = sizeof(flow_attr);
-        flow_attr.port = config.ib_port;
-
-        res->flow = ibv_create_flow(res->qp, &flow_attr);
-        if (res->flow == NULL) {
-            fprintf(stderr, "-E- Failed to set sniffer mode. ibv_create_flow failed: %s\n"
-                            "    This problem might be because Flow Steering is not enabled, to enable it:\n"
-                            "    1. Add the following to /etc/modprobe.d/mlnx.conf file:\n"
-                            "       options mlx4_core log_num_mgm_entry_size=-1\n"
-                            "    2. Restart the drivers.\n"
-                            ,strerror(errno));
-            return -1;
-        }
-    } else {
-        ibv_destroy_flow(res->flow);
-    }
-#else
+#ifdef LIBS_EXP
 
     if (mode != 0) {
         struct ibv_exp_flow_attr flow_attr;
@@ -885,6 +866,30 @@ int fourth_gen_set_sw_sniffer(struct resources *res, int mode,
     } else {
         ibv_exp_destroy_flow(res->flow);
     }
+
+#else
+
+    if (mode != 0) {
+            struct ibv_flow_attr flow_attr;
+            memset(&flow_attr, 0, sizeof(flow_attr));
+
+            flow_attr.type = IBV_FLOW_ATTR_SNIFFER;
+            flow_attr.size = sizeof(flow_attr);
+            flow_attr.port = config.ib_port;
+
+            res->flow = ibv_create_flow(res->qp, &flow_attr);
+            if (res->flow == NULL) {
+                fprintf(stderr, "-E- Failed to set sniffer mode. ibv_create_flow failed: %s\n"
+                                "    This problem might be because Flow Steering is not enabled, to enable it:\n"
+                                "    1. Add the following to /etc/modprobe.d/mlnx.conf file:\n"
+                                "       options mlx4_core log_num_mgm_entry_size=-1\n"
+                                "    2. Restart the drivers.\n"
+                                ,strerror(errno));
+                return -1;
+            }
+        } else {
+            ibv_destroy_flow(res->flow);
+        }
 
 #endif
 

--- a/ibdump.spec
+++ b/ibdump.spec
@@ -1,8 +1,8 @@
 %bcond_with mlnx_libs
 %if %{with mlnx_libs}
-%define upstream_arg %{nil}
+%define libs_exp_arg LIBS_EXP=yes
 %else
-%define upstream_arg UPSTREAM_KERNEL=yes
+%define libs_exp_arg %{nil}
 %endif
 
 %bcond_with mstflint
@@ -16,7 +16,7 @@
 %global make_build %{__make} %{?_smp_mflags}
 %endif
 
-%define make_opts %{upstream_arg} PREFIX=%{_prefix}
+%define make_opts %{libs_exp_arg} PREFIX=%{_prefix}
 
 Summary: Mellanox InfiniBand sniffing application
 Name: ibdump 


### PR DESCRIPTION
Description:
Update for PR #16: 
I changed the compilation flags in ibdump project.
OFED default verbs is changed to rdma-core, so ibdump must be aligned.

Changes:
* Debian build parameter renamed to "mlnx_libs" like the RPM one.
* A single commit

Issue: 2084499