### PR TITLE
Build ibdump failed with the OFED-5.xx

### DIFF
--- a/ibdump.h
+++ b/ibdump.h
@@ -98,10 +98,10 @@ struct resources {
     mfile*                  mf;             /* CR access handle */
 #endif
 #ifndef WIN_NOT_SUPPORTED
-#ifdef UPSTREAM_KERNEL
-    struct ibv_flow*        flow;
-#else
+#ifdef LIBS_EXP
     struct ibv_exp_flow*    flow;
+#else
+    struct ibv_flow*        flow;
 #endif
 #else
     void*                   ibal_ctx;


### PR DESCRIPTION
Description:
I changed the compilation flags in ibdump project.
OFED default verbs is changed to rdma-core, so ibdump must be aligned.

Issue: 2084499